### PR TITLE
Improve fastlane step

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -115,14 +115,20 @@ export FASTLANE_PASSWORD="$portal_password"
 ADHOC_FLAG=""
 [ "${deployment_type}" == "ad-hoc" ] && ADHOC_FLAG="--adhoc"
 
-fastlane "_"$fastlane_version"_" sigh -u ${portal_username} \
-              -b ${team_id} \
-              -a ${bundle_id} \
-              ${ADHOC_FLAG} \
-              -n "${profile_name}" \
-              -q "${target_filename}" \
-              --ignore_profiles_with_different_name \
-              --skip_certificate_verification
+COMMAND=sigh -u ${portal_username} \
+	              -b ${team_id} \
+	              -a ${bundle_id} \
+	              ${ADHOC_FLAG} \
+	              -n "${profile_name}" \
+	              -q "${target_filename}" \
+	              --ignore_profiles_with_different_name \
+	              --skip_certificate_verification
+
+if [ "${fastlane_version}" == "latest" ] ; then
+	fastlane COMMAND
+else
+	fastlane "_"$fastlane_version"_" COMMAND
+fi
 
 echo_info "Setting environment variable"
 envman add --key "${target_variable}" --value "file://./$target_filename"

--- a/step.sh
+++ b/step.sh
@@ -15,64 +15,64 @@ BLUE='\033[00;34m'
 GREEN='\033[00;32m'
 
 function color_echo {
-	color=$1
-	msg=$2
-	echo -e "${color}${msg}${RESTORE}"
+    color=$1
+    msg=$2
+    echo -e "${color}${msg}${RESTORE}"
 }
 
 function echo_fail {
-	msg=$1
-	echo
-	color_echo "${RED}" "${msg}"
-	exit 1
+    msg=$1
+    echo
+    color_echo "${RED}" "${msg}"
+    exit 1
 }
 
 function echo_warn {
-	msg=$1
-	color_echo "${YELLOW}" "${msg}"
+    msg=$1
+    color_echo "${YELLOW}" "${msg}"
 }
 
 function echo_info {
-	msg=$1
-	echo
-	color_echo "${BLUE}" "${msg}"
+    msg=$1
+    echo
+    color_echo "${BLUE}" "${msg}"
 }
 
 function echo_details {
-	msg=$1
-	echo "  ${msg}"
+    msg=$1
+    echo "  ${msg}"
 }
 
 function echo_done {
-	msg=$1
-	color_echo "${GREEN}" "  ${msg}"
+    msg=$1
+    color_echo "${GREEN}" "  ${msg}"
 }
 
 function validate_required_input {
-	key=$1
-	value=$2
-	if [ -z "${value}" ] ; then
-		echo_fail "[!] Missing required input: ${key}"
-	fi
+    key=$1
+    value=$2
+    if [ -z "${value}" ] ; then
+        echo_fail "[!] Missing required input: ${key}"
+    fi
 }
 
 function validate_required_input_with_options {
-	key=$1
-	value=$2
-	options=$3
+    key=$1
+    value=$2
+    options=$3
 
-	validate_required_input "${key}" "${value}"
+    validate_required_input "${key}" "${value}"
 
-	found="0"
-	for option in "${options[@]}" ; do
-		if [ "${option}" == "${value}" ] ; then
-			found="1"
-		fi
-	done
+    found="0"
+    for option in "${options[@]}" ; do
+        if [ "${option}" == "${value}" ] ; then
+            found="1"
+        fi
+    done
 
-	if [ "${found}" == "0" ] ; then
-		echo_fail "Invalid input: (${key}) value: (${value}), valid options: ($( IFS=$", "; echo "${options[*]}" ))"
-	fi
+    if [ "${found}" == "0" ] ; then
+        echo_fail "Invalid input: (${key}) value: (${value}), valid options: ($( IFS=$", "; echo "${options[*]}" ))"
+    fi
 }
 
 #=======================================
@@ -105,9 +105,9 @@ validate_required_input "fastlane_version" $fastlane_version
 
 echo_info "Installing required gem: fastlane"
 if [ "${fastlane_version}" == "latest" ] ; then
-	gem install fastlane
+    gem install fastlane
 else
-	gem install fastlane -v $fastlane_version
+    gem install fastlane -v $fastlane_version
 fi
 
 echo_info "Downloading provisioning profile"
@@ -116,18 +116,18 @@ ADHOC_FLAG=""
 [ "${deployment_type}" == "ad-hoc" ] && ADHOC_FLAG="--adhoc"
 
 COMMAND=sigh -u ${portal_username} \
-	              -b ${team_id} \
-	              -a ${bundle_id} \
-	              ${ADHOC_FLAG} \
-	              -n "${profile_name}" \
-	              -q "${target_filename}" \
-	              --ignore_profiles_with_different_name \
-	              --skip_certificate_verification
+                -b ${team_id} \
+                -a ${bundle_id} \
+                ${ADHOC_FLAG} \
+                -n "${profile_name}" \
+                -q "${target_filename}" \
+                --ignore_profiles_with_different_name \
+                --skip_certificate_verification
 
 if [ "${fastlane_version}" == "latest" ] ; then
-	fastlane COMMAND
+    fastlane COMMAND
 else
-	fastlane "_"$fastlane_version"_" COMMAND
+    fastlane "_"$fastlane_version"_" COMMAND
 fi
 
 echo_info "Setting environment variable"

--- a/step.sh
+++ b/step.sh
@@ -82,14 +82,15 @@ function validate_required_input_with_options {
 #
 # Validate parameters
 echo_info "Configs:"
-echo_details "* profile_name: $profile_name"
-echo_details "* bundle_id: $bundle_id"
-echo_details "* team_id: $team_id"
-echo_details "* portal_username: $portal_username"
+echo_details "* profile_name: ${profile_name}"
+echo_details "* bundle_id: ${bundle_id}"
+echo_details "* team_id: ${team_id}"
+echo_details "* portal_username: ${portal_username}"
 echo_details "* portal_password: ***"
-echo_details "* deployment_type: $deployment_type"
-echo_details "* target_variable: $target_variable"
-echo_details "* target_filename: $target_filename"
+echo_details "* deployment_type: ${deployment_type}"
+echo_details "* target_variable: ${target_variable}"
+echo_details "* target_filename: ${target_filename}"
+echo_details "* fastlane_version: ${fastlane_version}"
 echo
 
 validate_required_input "profile_name" $profile_name
@@ -100,30 +101,51 @@ validate_required_input "portal_password" $portal_password
 validate_required_input "deployment_type" $deployment_type
 validate_required_input "target_variable" $target_variable
 validate_required_input "target_filename" $target_filename
+validate_required_input "fastlane_version" $fastlane_version
 
-# eval expanded_xcode_project_path="${xcode_project_path}"
-#
-# if [ ! -e "${expanded_xcode_project_path}/project.pbxproj" ]; then
-#   echo_fail "No valid Xcode project found at path: ${expanded_xcode_project_path}"
-# fi
-
-echo_info "Installing required gem: fastlane"
-gem install fastlane
+# Since 'latest' cannot be used a valid gem version, there is a logic to remove version commands.
+# Also, to avoid loosing time re-downloading an already installed fastlane version, the -v command is checked.
+if [ "${fastlane_version}" == "latest" ] ; then
+	if [ "$(fastlane -v | grep "^fastlane" | tail -1 )" == "" ] ; then
+		echo_info "Installing required gem: fastlane"
+		gem install fastlane
+	else
+		echo_info "Using $(fastlane -v | grep "^fastlane" | tail -1 )"
+	fi
+else
+	if [ "$(fastlane "_"$fastlane_version"_" -v | grep "^fastlane" | tail -1 )" != "fastlane ${fastlane_version}" ] ; then
+		echo_info "Installing required gem: fastlane"
+		gem install fastlane -v $fastlane_version
+	else
+		echo_info "Using $(fastlane "_"$fastlane_version"_" -v | grep "^fastlane" | tail -1 )"
+	fi
+fi
 
 echo_info "Downloading provisioning profile"
 export FASTLANE_PASSWORD="$portal_password"
 ADHOC_FLAG=""
-[ "$deployment_type" == "ad-hoc" ] && ADHOC_FLAG="--adhoc"
+[ "${deployment_type}" == "ad-hoc" ] && ADHOC_FLAG="--adhoc"
 
-fastlane sigh -u $portal_username \
-              -b $team_id \
-              -a $bundle_id \
-              $ADHOC_FLAG \
-              -n "$profile_name" \
-              -q "$target_filename" \
-              --ignore_profiles_with_different_name \
-              --skip_certificate_verification
+# The sigh command is duplicated to ensure that the correct fastlane version is used
+# this is done in case that a previous step installed a different version of fastlane
+if [ "${fastlane_version}" == "latest" ] ; then
+	fastlane sigh -u ${portal_username} \
+				  -b ${team_id} \
+				  -a ${bundle_id} \
+				  ${ADHOC_FLAG} \
+				  -n "${profile_name}" \
+				  -q "${target_filename}" \
+				  --ignore_profiles_with_different_name --skip_certificate_verification
+else
+	fastlane "_"$fastlane_version"_" sigh -u ${portal_username} \
+										  -b ${team_id} \
+										  -a ${bundle_id} \
+										  ${ADHOC_FLAG} \
+										  -n "${profile_name}" \
+										  -q "${target_filename}" \
+										  --ignore_profiles_with_different_name --skip_certificate_verification
+fi
 
 echo_info "Setting environment variable"
-envman add --key $target_variable --value "file://./$target_filename"
+envman add --key "${target_variable}" --value "file://./$target_filename"
 

--- a/step.sh
+++ b/step.sh
@@ -90,6 +90,7 @@ echo_details "* portal_password: ***"
 echo_details "* deployment_type: $deployment_type"
 echo_details "* target_variable: $target_variable"
 echo_details "* target_filename: $target_filename"
+echo_details "* fastlane_version: $fastlane_version"
 echo
 
 validate_required_input "profile_name" $profile_name
@@ -100,22 +101,21 @@ validate_required_input "portal_password" $portal_password
 validate_required_input "deployment_type" $deployment_type
 validate_required_input "target_variable" $target_variable
 validate_required_input "target_filename" $target_filename
-
-# eval expanded_xcode_project_path="${xcode_project_path}"
-#
-# if [ ! -e "${expanded_xcode_project_path}/project.pbxproj" ]; then
-#   echo_fail "No valid Xcode project found at path: ${expanded_xcode_project_path}"
-# fi
+validate_required_input "fastlane_version" $fastlane_version
 
 echo_info "Installing required gem: fastlane"
-gem install fastlane
+if [ "$fastlane_version" == "latest" ] ; then
+	gem install fastlane
+else
+	gem install fastlane -v $fastlane_version
+fi
 
 echo_info "Downloading provisioning profile"
 export FASTLANE_PASSWORD="$portal_password"
 ADHOC_FLAG=""
 [ "$deployment_type" == "ad-hoc" ] && ADHOC_FLAG="--adhoc"
 
-fastlane sigh -u $portal_username \
+fastlane "_"$fastlane_version"_" sigh -u $portal_username \
               -b $team_id \
               -a $bundle_id \
               $ADHOC_FLAG \

--- a/step.sh
+++ b/step.sh
@@ -82,15 +82,15 @@ function validate_required_input_with_options {
 #
 # Validate parameters
 echo_info "Configs:"
-echo_details "* profile_name: $profile_name"
-echo_details "* bundle_id: $bundle_id"
-echo_details "* team_id: $team_id"
-echo_details "* portal_username: $portal_username"
+echo_details "* profile_name: ${profile_name}"
+echo_details "* bundle_id: ${bundle_id}"
+echo_details "* team_id: ${team_id}"
+echo_details "* portal_username: ${portal_username}"
 echo_details "* portal_password: ***"
-echo_details "* deployment_type: $deployment_type"
-echo_details "* target_variable: $target_variable"
-echo_details "* target_filename: $target_filename"
-echo_details "* fastlane_version: $fastlane_version"
+echo_details "* deployment_type: ${deployment_type}"
+echo_details "* target_variable: ${target_variable}"
+echo_details "* target_filename: ${target_filename}"
+echo_details "* fastlane_version: ${fastlane_version}"
 echo
 
 validate_required_input "profile_name" $profile_name
@@ -104,7 +104,7 @@ validate_required_input "target_filename" $target_filename
 validate_required_input "fastlane_version" $fastlane_version
 
 echo_info "Installing required gem: fastlane"
-if [ "$fastlane_version" == "latest" ] ; then
+if [ "${fastlane_version}" == "latest" ] ; then
 	gem install fastlane
 else
 	gem install fastlane -v $fastlane_version
@@ -113,17 +113,17 @@ fi
 echo_info "Downloading provisioning profile"
 export FASTLANE_PASSWORD="$portal_password"
 ADHOC_FLAG=""
-[ "$deployment_type" == "ad-hoc" ] && ADHOC_FLAG="--adhoc"
+[ "${deployment_type}" == "ad-hoc" ] && ADHOC_FLAG="--adhoc"
 
-fastlane "_"$fastlane_version"_" sigh -u $portal_username \
-              -b $team_id \
-              -a $bundle_id \
-              $ADHOC_FLAG \
-              -n "$profile_name" \
-              -q "$target_filename" \
+fastlane "_"$fastlane_version"_" sigh -u ${portal_username} \
+              -b ${team_id} \
+              -a ${bundle_id} \
+              ${ADHOC_FLAG} \
+              -n "${profile_name}" \
+              -q "${target_filename}" \
               --ignore_profiles_with_different_name \
               --skip_certificate_verification
 
 echo_info "Setting environment variable"
-envman add --key $target_variable --value "file://./$target_filename"
+envman add --key "${target_variable}" --value "file://./$target_filename"
 

--- a/step.yml
+++ b/step.yml
@@ -18,6 +18,13 @@ is_skippable: false
 deps:
 run_if: ""
 inputs:
+  - fastlane_version: 'latest'
+    opts:
+      title: "Fastlane version"
+      summary: This allow you to specify a specific Fastlane version to be used by the script.
+      description: This allow you to specify a specific Fastlane version to be used by the script.
+      is_expand: false
+      is_required: true
   - profile_name: ''
     opts:
       title: "Profile name"

--- a/step.yml
+++ b/step.yml
@@ -1,10 +1,9 @@
-title: "S3 Download"
-summary: This step allows to download a file from an S3 bucket.
+title: "Download provisioning profile"
+summary: This step allows to download a provisioning profile from Apple's portal using Fastlane.
 description: |-
-   This step allows to download a file from an S3 bucket using an Access/secret keypair
-   for authentication.
-website: https://github.com/FutureWorkshops/bitrise-step-s3-download
-source_code_url: https://github.com/FutureWorkshops/bitrise-step-s3-download
+   This step allows to download a file from the Apple's developer portal.
+website: https://github.com/FutureWorkshops/bitrise-step-download-provisioning-profile
+source_code_url: https://github.com/FutureWorkshops/bitrise-step-download-provisioning-profile
 host_os_tags:
   - osx-10.10
   - osx-10.9
@@ -24,25 +23,22 @@ inputs:
       title: "Profile name"
       summary: The provisioning profile name as it appears on the developer portal
       description: The provisioning profile name as it appears on the developer portal
-      is_expand: true
+      is_expand: false
       is_required: true
-      value_options: []
   - bundle_id: ''
     opts:
       title: "Bundle ID"
       summary: The bundle ID of the app
       description: 
-      is_expand: true
+      is_expand: false
       is_required: true
-      value_options: []
   - team_id: ''
     opts:
       title: "Team ID"
       summary: "The Apple developer portal's team ID"
       description: 
-      is_expand: true
+      is_expand: false
       is_required: true
-      value_options: []
   - deployment_type: 'app-store'
     opts:
       title: "Deployment type"
@@ -56,33 +52,29 @@ inputs:
       title: "Developer portal username"
       summary: "The username of a valid account to the Apple developer portal's"
       description: 
-      is_expand: true
+      is_expand: false
       is_required: true
-      value_options: []
   - portal_password: ''
     opts:
       title: "Developer portal password"
       summary: "The password of a valid account to the Apple developer portal's"
       description: 
-      is_expand: true
+      is_expand: false
       is_required: true
-      value_options: []
   - target_variable: 'PROVISIONING_PROFILE'
     opts:
       title: "Target env variable"
       summary: "Environment variable that will contain the path to the provisioning profile's name"
       description:  
-      is_expand: true
+      is_expand: false
       is_required: true
-      value_options: []
   - target_filename: 'profile.mobileprovision'
     opts:
       title: "Provisioning profile file name"
       summary: "The name of the local file where the provisioning profile will be saved"
       description:  
-      is_expand: true
+      is_expand: false
       is_required: true
-      value_options: []
 
 
 outputs:

--- a/step.yml
+++ b/step.yml
@@ -23,28 +23,28 @@ inputs:
       title: "Fastlane version"
       summary: This allow you to specify a specific Fastlane version to be used by the script.
       description: This allow you to specify a specific Fastlane version to be used by the script.
-      is_expand: false
+      is_expand: true
       is_required: true
   - profile_name: ''
     opts:
       title: "Profile name"
       summary: The provisioning profile name as it appears on the developer portal
       description: The provisioning profile name as it appears on the developer portal
-      is_expand: false
+      is_expand: true
       is_required: true
   - bundle_id: ''
     opts:
       title: "Bundle ID"
       summary: The bundle ID of the app
       description: 
-      is_expand: false
+      is_expand: true
       is_required: true
   - team_id: ''
     opts:
       title: "Team ID"
       summary: "The Apple developer portal's team ID"
       description: 
-      is_expand: false
+      is_expand: true
       is_required: true
   - deployment_type: 'app-store'
     opts:
@@ -59,28 +59,28 @@ inputs:
       title: "Developer portal username"
       summary: "The username of a valid account to the Apple developer portal's"
       description: 
-      is_expand: false
+      is_expand: true
       is_required: true
   - portal_password: ''
     opts:
       title: "Developer portal password"
       summary: "The password of a valid account to the Apple developer portal's"
       description: 
-      is_expand: false
+      is_expand: true
       is_required: true
   - target_variable: 'PROVISIONING_PROFILE'
     opts:
       title: "Target env variable"
       summary: "Environment variable that will contain the path to the provisioning profile's name"
       description:  
-      is_expand: false
+      is_expand: true
       is_required: true
   - target_filename: 'profile.mobileprovision'
     opts:
       title: "Provisioning profile file name"
       summary: "The name of the local file where the provisioning profile will be saved"
       description:  
-      is_expand: false
+      is_expand: true
       is_required: true
 
 

--- a/step.yml
+++ b/step.yml
@@ -1,10 +1,10 @@
-title: "S3 Download"
-summary: This step allows to download a file from an S3 bucket.
+title: "Download Provisioning Profile"
+summary: This step allows to download a specific provisioning profile from Apple's developer portal
 description: |-
-   This step allows to download a file from an S3 bucket using an Access/secret keypair
-   for authentication.
-website: https://github.com/FutureWorkshops/bitrise-step-s3-download
-source_code_url: https://github.com/FutureWorkshops/bitrise-step-s3-download
+   This step allows to download a specific provisioning profile from Apple's developer portal,
+   using the Fastlane gem to do so.
+website: https://github.com/FutureWorkshops/bitrise-step-download-provisioning-profile
+source_code_url: https://github.com/FutureWorkshops/bitrise-step-download-provisioning-profile/pull/1
 host_os_tags:
   - osx-10.10
   - osx-10.9
@@ -19,6 +19,13 @@ is_skippable: false
 deps:
 run_if: ""
 inputs:
+  - fastlane_version: 'latest'
+    opts:
+      title: "Fastlane version"
+      summary: "Set the fastlane version to be used"
+      description: "The developer is allowed to set a specific version of the fastlane gem to be used during the step"
+      is_expand: true
+      is_required: true
   - profile_name: ''
     opts:
       title: "Profile name"
@@ -26,7 +33,6 @@ inputs:
       description: The provisioning profile name as it appears on the developer portal
       is_expand: true
       is_required: true
-      value_options: []
   - bundle_id: ''
     opts:
       title: "Bundle ID"
@@ -34,7 +40,6 @@ inputs:
       description: 
       is_expand: true
       is_required: true
-      value_options: []
   - team_id: ''
     opts:
       title: "Team ID"
@@ -42,7 +47,6 @@ inputs:
       description: 
       is_expand: true
       is_required: true
-      value_options: []
   - deployment_type: 'app-store'
     opts:
       title: "Deployment type"
@@ -58,7 +62,6 @@ inputs:
       description: 
       is_expand: true
       is_required: true
-      value_options: []
   - portal_password: ''
     opts:
       title: "Developer portal password"
@@ -66,15 +69,13 @@ inputs:
       description: 
       is_expand: true
       is_required: true
-      value_options: []
-  - target_variable: 'PROVISIONING_PROFILE'
+  - target_variable: '$PROVISIONING_PROFILE'
     opts:
       title: "Target env variable"
       summary: "Environment variable that will contain the path to the provisioning profile's name"
       description:  
       is_expand: true
       is_required: true
-      value_options: []
   - target_filename: 'profile.mobileprovision'
     opts:
       title: "Provisioning profile file name"
@@ -82,7 +83,6 @@ inputs:
       description:  
       is_expand: true
       is_required: true
-      value_options: []
 
 
 outputs:

--- a/step.yml
+++ b/step.yml
@@ -1,7 +1,6 @@
 title: "Download provisioning profile"
 summary: This step allows to download a provisioning profile from Apple's portal using Fastlane.
-description: |-
-   This step allows to download a file from the Apple's developer portal.
+description: This step allows to download a file from the Apple's developer portal.
 website: https://github.com/FutureWorkshops/bitrise-step-download-provisioning-profile
 source_code_url: https://github.com/FutureWorkshops/bitrise-step-download-provisioning-profile
 host_os_tags:


### PR DESCRIPTION
This PR aims to fix the download provision profile step by enabling the developer to use the pre-installed version of fastlane (if any) before downloading the gem. Also, creates the option to set a specific fastlane version to use, so we can use an old version to bypass bad releases.